### PR TITLE
Change max processes to 5

### DIFF
--- a/pkg/mc/mc.go
+++ b/pkg/mc/mc.go
@@ -114,7 +114,7 @@ mc -r kind -o json -- get pods -n kube-system | jq 'keys[] as $k | "\($k) \(.[$k
 	cmd.Flags().StringVarP(&mc.Regex, "regex", "r", mc.Regex, "a regex to filter the list of context names in kubeconfig. If not given all contexts are used")
 	cmd.Flags().StringVarP(&mc.NegRegex, "negative-regex", "n", mc.NegRegex, "a regex to exclude matches from the result set. Evaluated succeeding to the including regex filter")
 	cmd.Flags().BoolVarP(&mc.ListOnly, "list-only", "l", mc.ListOnly, "just list the contexts matching the regex. Good for testing your regex")
-	cmd.Flags().IntVarP(&mc.MaxProc, "max-processes", "p", 10, "max amount of parallel kubectl to be executed. Can be used to limit cpu activity")
+	cmd.Flags().IntVarP(&mc.MaxProc, "max-processes", "p", 5, "max amount of parallel kubectl to be executed. Can be used to limit cpu activity")
 	cmd.Flags().BoolVarP(&mc.Debug, "debug", "d", mc.Debug, "enable debug output")
 	cmd.Flags().StringVarP(&mc.Output, "output", "o", mc.Output, fmt.Sprintf("specify the output format. Useful for parsing with another tool like jq or yq. One of %s", outputsString()))
 


### PR DESCRIPTION
In some rare occasions on weaker machines 10 can eat up all the CPU on a machine and make it unresponsive.
The default can still be overwritten to achieve higher parallelization.