### PR TITLE
Allow --raw argument with -o json

### DIFF
--- a/pkg/mc/mc.go
+++ b/pkg/mc/mc.go
@@ -105,7 +105,13 @@ mc -r kind -o json -- get pods -n kube-system | jq 'keys[] as $k | "\($k) \(.[$k
 				if _, ok := outputs[mc.Output]; !ok {
 					return errUnknownOutput
 				}
-				args = append(args, "-o", "json")
+				raw := false
+				for _, arg := range args {
+					raw = raw || strings.HasPrefix(arg, "--raw")
+				}
+				if !raw {
+					args = append(args, "-o", "json")
+				}
 			}
 			if len(args) == 0 && !mc.ListOnly {
 				cmd.Usage()


### PR DESCRIPTION
This fixes a bug where the `--raw` argument was used in conjunction with `-o json`.
When the `--raw` argument is given we don't need to inject the `-o json`
flag to the kubectl command as that's not allowed by kubectl.

No test added as we mock the kubectl response anyway