### PR TITLE
Fix error handling for parsed output

### DIFF
--- a/pkg/mc/mc.go
+++ b/pkg/mc/mc.go
@@ -240,15 +240,17 @@ func do(done chan bool, context string, namespace string, output map[string]json
 	stdout, err := kubectl(cmd)
 	if err != nil {
 		stdout = []byte(err.Error())
-	}
-	mutex.Lock()
+		logger.Debug("kubectl error", zap.Error(err))
+	} else {
+		mutex.Lock()
 
-	cns := context
-	if namespace != "" {
-		cns += ": " + namespace
+		cns := context
+		if namespace != "" {
+			cns += ": " + namespace
+		}
+		output[cns] = stdout
+		mutex.Unlock()
 	}
-	output[cns] = stdout
-	mutex.Unlock()
 	if writeToStdout {
 		fmt.Fprint(out, formatContext(context, namespace, stdout))
 	}
@@ -259,7 +261,7 @@ func do(done chan bool, context string, namespace string, output map[string]json
 func kubectl(cmd Cmd) ([]byte, error) {
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf(strings.Replace(strings.Replace(string(out), "error: ", "", -1), "Error: ", "", -1))
+		return nil, fmt.Errorf(strings.Replace(strings.Replace(string(err.(*exec.ExitError).Stderr), "error: ", "", -1), "Error: ", "", -1))
 	}
 	return out, nil
 }

--- a/pkg/mc/mc.go
+++ b/pkg/mc/mc.go
@@ -261,7 +261,11 @@ func do(done chan bool, context string, namespace string, output map[string]json
 func kubectl(cmd Cmd) ([]byte, error) {
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf(strings.Replace(strings.Replace(string(err.(*exec.ExitError).Stderr), "error: ", "", -1), "Error: ", "", -1))
+		errString := err.Error()
+		if err, ok := err.(*exec.ExitError); ok {
+			errString = string(err.Stderr)
+		}
+		return nil, fmt.Errorf(strings.Replace(strings.Replace(errString, "error: ", "", -1), "Error: ", "", -1))
 	}
 	return out, nil
 }

--- a/pkg/mc/mc_test.go
+++ b/pkg/mc/mc_test.go
@@ -3,8 +3,8 @@ package mc
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io/ioutil"
+	"os/exec"
 	"sync"
 	"testing"
 
@@ -188,8 +188,8 @@ func TestKubectl(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, kubectlReturn, got)
 
-	m.EXPECT().Output().Return([]byte(`Error: unknown shorthand flag: 'a' in -abc
-See 'kubectl get --help' for usage.`), errors.New(""))
+	m.EXPECT().Output().Return(nil, &exec.ExitError{Stderr: []byte(`Error: unknown shorthand flag: 'a' in -abc
+See 'kubectl get --help' for usage.`)})
 
 	got, err = kubectl(m)
 	assert.Nil(t, got)


### PR DESCRIPTION
parsed outputs always failed because the output string was empty.
Now we don't even add the output to the map in case of an error, but we write it to the debug output.