### PR TITLE
Add arm builds to krew index

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -20,9 +20,21 @@ spec:
     bin: kubectl-mc
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/jonnylangefeld/kubectl-mc/releases/download/{{ .TagName }}/kubectl-mc_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-mc
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     {{addURIAndSha "https://github.com/jonnylangefeld/kubectl-mc/releases/download/{{ .TagName }}/kubectl-mc_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-mc
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/jonnylangefeld/kubectl-mc/releases/download/{{ .TagName }}/kubectl-mc_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
     bin: kubectl-mc
   - selector:
       matchLabels:


### PR DESCRIPTION
Currently when trying to use `krew` to install `mc` on an arm based system, I see the following (even though I know there are arm based builds on the releases page):

```
╰─ krew search mc
NAME           DESCRIPTION                                         INSTALLED
...
mc             Run kubectl commands against multiple clusters ...  unavailable on darwin/arm64
...
```

I believe the only thing to correct this is addressed by this PR adding the paths to the ARM builds to the krew index file.